### PR TITLE
Add configurable logging level support

### DIFF
--- a/config.py
+++ b/config.py
@@ -37,3 +37,6 @@ HEADERS = {"User-Agent": "Mozilla/5.0"}
 MIN_INTERVAL = 1
 MAX_INTERVAL = 5
 MAX_ITEMS = 3
+
+# ログ出力のデフォルトレベル
+LOG_LEVEL = "INFO"

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,11 +1,64 @@
+"""ロギング設定を初期化するユーティリティ。"""
+
+from __future__ import annotations
+
 import logging
 import os
 from datetime import datetime
+from typing import List, Optional, Tuple
 
-def setup_logging():
-    """
-    ログ設定を行う関数
-    """
+
+def _coerce_log_level(level_name: Optional[str]) -> Optional[int]:
+    """文字列で指定されたログレベルを数値レベルに変換する。"""
+
+    if not level_name:
+        return None
+
+    level = getattr(logging, level_name.upper(), None)
+    return level if isinstance(level, int) else None
+
+
+def _select_log_level(
+    cli_level: Optional[str],
+    env_level: Optional[str],
+    default_level: Optional[str],
+) -> Tuple[int, str, List[str]]:
+    """ログレベルの決定と警告メッセージの収集を行う。"""
+
+    warnings: List[str] = []
+
+    for source, candidate in (
+        ("CLI 引数", cli_level),
+        ("環境変数 SCRAPING_LOG_LEVEL", env_level),
+    ):
+        level = _coerce_log_level(candidate)
+        if level is not None:
+            return level, source, warnings
+        if candidate:
+            warnings.append(
+                f"{source} で指定されたログレベル '{candidate}' は無効です。"
+            )
+
+    fallback_source = "config.LOG_LEVEL"
+    level = _coerce_log_level(default_level)
+    if level is None:
+        if default_level:
+            warnings.append(
+                f"{fallback_source} に無効なログレベル '{default_level}' が設定されています。"
+            )
+        level = logging.DEBUG
+        fallback_source = "デフォルト (DEBUG)"
+
+    return level, fallback_source, warnings
+
+
+def setup_logging(
+    log_level: Optional[str] = None,
+    enable_console: bool = True,
+    default_level: Optional[str] = None,
+) -> None:
+    """ロギング設定を構成する。"""
+
     log_dir = "log"
     os.makedirs(log_dir, exist_ok=True)
 
@@ -13,17 +66,40 @@ def setup_logging():
     log_filename = f"scraping_{timestamp}.log"
     log_filepath = os.path.join(log_dir, log_filename)
 
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(levelname)s - %(message)s",
-        filename=log_filepath,
-        filemode="w",
-        encoding="utf-8"
+    level, source, warnings = _select_log_level(
+        cli_level=log_level,
+        env_level=os.environ.get("SCRAPING_LOG_LEVEL"),
+        default_level=default_level,
+    )
+    log_format = (
+        "%(asctime)s - %(levelname)s - %(name)s - %(funcName)s:%(lineno)d - %(message)s"
     )
 
-    # コンソールにもログを出力したい場合は、以下のハンドラを追加
-    # console_handler = logging.StreamHandler()
-    # console_handler.setLevel(logging.INFO)
-    # formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-    # console_handler.setFormatter(formatter)
-    # logging.getLogger().addHandler(console_handler)
+    logging.basicConfig(
+        level=level,
+        format=log_format,
+        filename=log_filepath,
+        filemode="w",
+        encoding="utf-8",
+        force=True,
+    )
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+
+    if enable_console:
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(level)
+        console_handler.setFormatter(logging.Formatter(log_format))
+        root_logger.addHandler(console_handler)
+
+    for warning_message in warnings:
+        root_logger.warning(warning_message)
+
+    root_logger.debug(
+        "ロギングを初期化しました。レベル=%s, 決定元=%s, 出力ファイル=%s",
+        logging.getLevelName(level),
+        source,
+        log_filepath,
+    )
+

--- a/utils.py
+++ b/utils.py
@@ -1,24 +1,39 @@
 import logging
 import random
 import time
+
 import requests
 from bs4 import BeautifulSoup
+
 import config
 
+
 def get_soup(url):
-    """
-    指定されたURLからBeautifulSoupオブジェクトを取得する
-    """
+    """指定されたURLからBeautifulSoupオブジェクトを取得する"""
     try:
         sleep_time = random.uniform(config.MIN_INTERVAL, config.MAX_INTERVAL)
-        logging.info(f"{sleep_time:.2f}秒待機します...")
+        logging.debug("HTTPリクエスト前に %.2f 秒待機します url=%s", sleep_time, url)
         time.sleep(sleep_time)
-        
+
+        logging.debug("HTTPリクエストを送信します url=%s headers=%s", url, config.HEADERS)
         res = requests.get(url, headers=config.HEADERS, timeout=10)
+        logging.debug("HTTPレスポンスを受信しました status_code=%s url=%s", res.status_code, url)
+
         # res.encoding = res.apparent_encoding
         res.encoding = 'utf-8'
         res.raise_for_status()
-        return BeautifulSoup(res.text, "html.parser")
+
+        soup = BeautifulSoup(res.text, "html.parser")
+        logging.debug(
+            "BeautifulSoupオブジェクトを生成しました url=%s content_length=%d",
+            url,
+            len(res.text),
+        )
+        return soup
+    except requests.Timeout:
+        logging.error("タイムアウトが発生しました url=%s", url)
     except requests.RequestException as e:
-        logging.error(f"ページの取得エラー ({url}): {e}")
-        return None
+        logging.error("ページの取得エラー (%s): %s", url, e)
+
+    logging.debug("URLの取得に失敗したため None を返します url=%s", url)
+    return None


### PR DESCRIPTION
## Summary
- add a LOG_LEVEL default to the configuration so logging can inherit a baseline level
- overhaul logging_config to resolve log level precedence between CLI, environment, and defaults while writing console/file output with enriched formatting
- update main CLI to accept --log-level, pass it into logging setup, and log the selected site configuration and max item limit

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dabca6596c832eb00d4dffb45100fc