### PR TITLE
Enhance header spoofing and logging clarity

### DIFF
--- a/config.py
+++ b/config.py
@@ -88,32 +88,45 @@ SITE_CONFIGS = {
 }
 
 # --- スクレイピング制御設定 (共通) ---
-HEADERS = {
-    "authority": "internshipguide.jp",
+CHROME_HEADER_PROFILES = [
+    {
+        "user_agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/125.0.6422.141 Safari/537.36"
+        ),
+        "sec_ch_ua": '"Not/A)Brand";v="8", "Chromium";v="125", "Google Chrome";v="125"',
+        "sec_ch_ua_platform": '"Windows"',
+        "sec_ch_ua_mobile": "?0",
+    },
+    {
+        "user_agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/126.0.6478.54 Safari/537.36"
+        ),
+        "sec_ch_ua": '"Not/A)Brand";v="8", "Chromium";v="126", "Google Chrome";v="126"',
+        "sec_ch_ua_platform": '"macOS"',
+        "sec_ch_ua_mobile": "?0",
+    },
+]
+
+BASE_HEADERS = {
     "accept": (
         "text/html,application/xhtml+xml,application/xml;"
         "q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,"
         "application/signed-exchange;v=b3;q=0.7"
     ),
     "accept-language": "ja,en-US;q=0.9,en;q=0.8",
-    "cache-control": "max-age=0",
+    "cache-control": "no-cache",
     "dnt": "1",
-    "referer": "https://internshipguide.jp/interns/japanInternList/13?longterm=1",
-    "sec-ch-ua": (
-        '"Google Chrome";v="124", "Chromium";v="124", "Not-A.Brand";v="99"'
-    ),
+    "pragma": "no-cache",
     "sec-ch-ua-mobile": "?0",
-    "sec-ch-ua-platform": '"Windows"',
     "sec-fetch-dest": "document",
     "sec-fetch-mode": "navigate",
-    "sec-fetch-site": "same-origin",
+    "sec-fetch-site": "none",
     "sec-fetch-user": "?1",
     "upgrade-insecure-requests": "1",
-    "user-agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/124.0.0.0 Safari/537.36"
-    ),
 }
 MIN_INTERVAL = 3
 MAX_INTERVAL = 10

--- a/main.py
+++ b/main.py
@@ -105,8 +105,11 @@ def main(
         output_dir = "output"
         resume_file = os.path.join(output_dir, f'{site}_job_listings.csv')
 
-        print(f"CWD: {os.getcwd()}")
-        print(f"Checking for file: {os.path.abspath(resume_file)}")
+        logging.debug(
+            "再開対象ファイルを確認します。cwd=%s path=%s",
+            os.getcwd(),
+            os.path.abspath(resume_file),
+        )
 
         if os.path.exists(resume_file):
             logging.info(f"既存のファイル: {resume_file}")

--- a/utils.py
+++ b/utils.py
@@ -1,54 +1,90 @@
 import logging
 import random
 import time
-from typing import Optional, Dict
+from typing import Dict, Optional
+from urllib.parse import urlparse
 
-import requests
 import tls_client
 from bs4 import BeautifulSoup
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 import config
 
+logger = logging.getLogger(__name__)
+
+
+def _determine_sec_fetch_site(target_host: str, referer: Optional[str]) -> str:
+    if not referer:
+        return "none"
+
+    referer_host = urlparse(referer).netloc
+    if referer_host == target_host:
+        return "same-origin"
+    return "cross-site"
+
+
+def build_chrome_like_headers(
+    url: str,
+    overrides: Optional[Dict[str, str]] = None,
+) -> Dict[str, str]:
+    """Chromeブラウザからのアクセスを模したヘッダーを生成する。"""
+
+    overrides = dict(overrides or {})
+    target_host = urlparse(url).netloc
+    sec_fetch_site = _determine_sec_fetch_site(target_host, overrides.get("Referer") or overrides.get("referer"))
+
+    profile = random.choice(config.CHROME_HEADER_PROFILES)
+
+    headers: Dict[str, str] = {
+        **config.BASE_HEADERS,
+        "authority": target_host,
+        "host": target_host,
+        "sec-ch-ua": profile["sec_ch_ua"],
+        "sec-ch-ua-mobile": profile.get("sec_ch_ua_mobile", "?0"),
+        "sec-ch-ua-platform": profile["sec_ch_ua_platform"],
+        "sec-fetch-site": sec_fetch_site,
+        "user-agent": profile["user_agent"],
+    }
+
+    headers.update(overrides)
+    return headers
+
+
 # --- セッションとリトライ設定 ---
-def get_soup(url: str, headers: Optional[Dict[str, str]] = None):
-    """
-    指定されたURLからBeautifulSoupオブジェクトを取得する。
-    リトライ機能と堅牢なエンコーディング設定を持つセッションを使用する。
-    """
+def get_soup(url: str, headers: Optional[Dict[str, str]] = None) -> Optional[BeautifulSoup]:
+    """指定されたURLからBeautifulSoupオブジェクトを取得する。"""
+
     try:
-        # Use tls_client session
         session = tls_client.Session(
             client_identifier="chrome_112",
-            random_tls_extension_order=True
+            random_tls_extension_order=True,
         )
 
-        request_headers = headers if headers is not None else config.HEADERS
+        request_headers = build_chrome_like_headers(url, headers)
         sleep_time = random.uniform(config.MIN_INTERVAL, config.MAX_INTERVAL)
-        logging.debug("HTTPリクエスト前に %.2f 秒待機します url=%s", sleep_time, url)
+        logger.debug("HTTPリクエスト前に %.2f 秒待機します url=%s", sleep_time, url)
         time.sleep(sleep_time)
 
-        logging.debug("HTTPリクエストを送信します url=%s headers=%s", url, request_headers)
-        res = session.get(url, headers=request_headers)
-        logging.debug("HTTPレスポンスを受信しました status_code=%s url=%s", res.status_code, url)
+        logger.debug("HTTPリクエストを送信します url=%s headers=%s", url, request_headers)
+        response = session.get(url, headers=request_headers)
+        logger.debug(
+            "HTTPレスポンスを受信しました status_code=%s url=%s", response.status_code, url
+        )
 
-
-
-        # ステータスコードに基づいてエラーハンドリング
-        if res.status_code != 200:
-            logging.error(f"ページの取得エラー ({url}): status_code={res.status_code}")
+        if response.status_code != 200:
+            logger.error(
+                "ページの取得エラー (%s): status_code=%s", url, response.status_code
+            )
             return None
 
-        soup = BeautifulSoup(res.text, "html.parser")
-        logging.debug(
+        soup = BeautifulSoup(response.text, "html.parser")
+        logger.debug(
             "BeautifulSoupオブジェクトを生成しました url=%s content_length=%d",
             url,
-            len(res.text),
+            len(response.text),
         )
         return soup
-    except Exception as e:
-        logging.error("ページの取得エラー (%s): %s", url, e)
+    except Exception as exc:  # noqa: BLE001 - 広範囲のエラーをログに残すため
+        logger.error("ページの取得エラー (%s): %s", url, exc)
 
-    logging.debug("URLの取得に失敗したため None を返します url=%s", url)
+    logger.debug("URLの取得に失敗したため None を返します url=%s", url)
     return None


### PR DESCRIPTION
## Summary
- replace the static header config with configurable Chrome-like header profiles
- generate spoofed request headers inside utils.get_soup and improve HTTP logging
- tidy scraping resume logging and referer handling in the base scraper

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68f109cfa8e8832e83aedfb6d9674065